### PR TITLE
added TypeScript definition file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ This is up to you. All you get is:
 
 This repository has no advice as to how to run the jar. Other libraries should
 fill that void; they can depend on this library to keep things simple.
+
+### TypeScript
+
+This library includes a TypeScript definition file. If you're using TypeScript,
+you can use this library like this:
+
+    import * as jar from 'selenium-server-standalone-jar';
+    console.log(jar.path);    // path to selenium-server-standalone-X.YY.Z.jar
+    console.log(jar.version); // X.YY.Z

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "mocha"
   },
+  "types": "typings/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/adamhooper/selenium-server-standalone-jar.git"

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Absolute path to the jar file with the standalone selenium server.
+ * You can use this path directly to start the server in other packages, e.g.
+ * ```
+ * import * as jar from 'selenium-server-standalone-jar';
+ * import * as remote from "selenium-webdriver/remote";
+ * declare global { var server: any; }
+ * globalThis.server = new remote.SeleniumServer(jar.path, {port: 8080});
+ * await globalThis.server.start();
+ * ```
+ */
+export const path: string
+/**
+ * Version of the standalone selenium server.
+ */
+export const version: string


### PR DESCRIPTION
In order to use this really useful package with TypeScript, a definition file is required. It is really tiny, maybe you could add this in this library directly, then there is no need to install another @types package (which is not available anyway, and I thought is would be much easier to have it here directly).